### PR TITLE
add gauge for running task durations

### DIFF
--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -281,7 +281,7 @@ def get_task_duration_info():
         )
 
 def get_running_task_duration_info():
-    """Duration of successful tasks in seconds."""
+    """Duration of running tasks in seconds."""
     with session_scope(Session) as session:
         max_execution_dt_query = (
             session.query(

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -280,6 +280,50 @@ def get_task_duration_info():
             .all()
         )
 
+def get_running_task_duration_info():
+    """Duration of successful tasks in seconds."""
+    with session_scope(Session) as session:
+        max_execution_dt_query = (
+            session.query(
+                DagRun.dag_id,
+                func.max(DagRun.execution_date).label("max_execution_dt"),
+            )
+            .join(DagModel, DagModel.dag_id == DagRun.dag_id,)
+            .filter(
+                DagModel.is_active == True,  # noqa
+                DagModel.is_paused == False,
+                DagRun.state == State.RUNNING,
+            )
+            .group_by(DagRun.dag_id)
+            .subquery()
+        )
+
+        return (
+            session.query(
+                TaskInstance.dag_id,
+                TaskInstance.task_id,
+                TaskInstance.start_date,
+                TaskInstance.end_date,
+                TaskInstance.execution_date,
+            )
+            .join(
+                max_execution_dt_query,
+                and_(
+                    (TaskInstance.dag_id == max_execution_dt_query.c.dag_id),
+                    (
+                        TaskInstance.execution_date
+                        == max_execution_dt_query.c.max_execution_dt
+                    ),
+                ),
+            )
+            .filter(
+                TaskInstance.state == State.RUNNING,
+                TaskInstance.start_date.isnot(None),
+                TaskInstance.end_date.isnot(None),
+            )
+            .all()
+        )
+
 
 ######################
 # Scheduler Related Metrics
@@ -384,6 +428,22 @@ class MetricsCollector(object):
             )
         yield task_duration
 
+        running_task_duration = GaugeMetricFamily(
+            "airflow_running_task_duration",
+            "Duration of running tasks in seconds",
+            labels=["task_id", "dag_id", "execution_date"],
+        )
+        for task in get_running_task_duration_info():
+            running_task_duration_value = (
+                task.end_date - task.start_date
+            ).total_seconds()
+            running_task_duration.add_metric(
+                [task.task_id, task.dag_id, str(task.execution_date.date())],
+                running_task_duration_value,
+            )
+        yield running_task_duration
+
+
         task_failure_count = GaugeMetricFamily(
             "airflow_task_fail_count",
             "Count of failed tasks",
@@ -411,6 +471,7 @@ class MetricsCollector(object):
             "Duration of successful dag_runs in seconds",
             labels=["dag_id"],
         )
+
         for dag in get_dag_duration_info():
             dag_duration_value = (
                 dag.end_date - dag.start_date


### PR DESCRIPTION
**Background**
We sometimes have tasks that get stuck in the running state and back up airflow DAGs.  We can't detect them currently as the robinhood prometheus exporter does not produce metrics for running tasks.  My best guess as to why is that you won't get consistent data for each gauge as sometimes a task will be running and sometimes it wont.

I think our ultimate goal is to see if we can detect any task running above a given threshold to throw an alert.  (Please provide other ideas). 

With everything going on, getting this deployed is a important, but not highly urgent.

**This pr**
https://ringdna.atlassian.net/browse/DATA-1968
Pulled down the fork of the prometheus exporter that pete got for us, and I think this is all it takes to add a new metric.  Also good to know we can clean up metrics we no longer want to track.

It might be better to do this for DAG run duration as opposed to task run duration because there will be fewer unique metrics even though it is the task itself that can get stuck.  What do you think?